### PR TITLE
CDD-2831_Fix_missing_flexmark_lib

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -10,6 +10,6 @@ object AppDependencies {
     "uk.gov.hmrc" %% "bootstrap-play-25" % bootStrapPlayVersion)
 
   val test = Seq(
-    "org.pegdown" % "pegdown" % "1.6.0" % "test",
-    "org.scalatest" %% "scalatest" % "3.2.0" % "test")
+    "com.vladsch.flexmark" % "flexmark-all" % "0.35.10" % Test,
+    "org.scalatest" %% "scalatest" % "3.2.0" % Test)
 }

--- a/test/BuildSpec.scala
+++ b/test/BuildSpec.scala
@@ -16,10 +16,12 @@
 
 package test
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
 import sys.process._
 
-class BuildSpec extends WordSpec with Matchers {
+class BuildSpec extends AnyWordSpec with Matchers {
   "Building the content" should {
     "produce static files" in {
       val result = "bundle install" #&& Process("bundle exec middleman build --build-dir=public/ --clean", None, "BASE_PATH" -> "/guides/customs-declarations-end-to-end-service-guide/") !


### PR DESCRIPTION
Previous versions of ScalaTest used Pegdown to generating the test reports which is now abandoned. So replacing with flexmark-all lib